### PR TITLE
Adds support for Nomorobo

### DIFF
--- a/usr/share/callblocker/onlinecheck_nomorobo_com.py
+++ b/usr/share/callblocker/onlinecheck_nomorobo_com.py
@@ -27,7 +27,7 @@ class OnlineCheckNomorobo(OnlineBase):
         return ["+1"]
 
     def handle_number(self, args, number):
-        number = '{}-{}-{}'.format(number[2:5], number[5:8], number[8:]) # make number local
+        number = '{}-{}-{}'.format(number[2:5], number[5:8], number[8:]) # make number local for US
         url = "https://www.nomorobo.com/lookup/%s" % number
         headers={}
         allowed_codes=[404] # allow not found response
@@ -40,15 +40,17 @@ class OnlineCheckNomorobo(OnlineBase):
         if len(positions) > 0:
             position = positions[0].get_text()
             if position.upper().find("DO NOT ANSWER") > -1:
-                score = 2 # is spam
+                score = 2 # = is spam
             else:
-                score = 1 # may be spam
+                score = 1 # = might be spam (caller is "Political", "Charity", or "Debt Collector")
 
         caller_name = ""
         titles = soup.findAll(class_="profile-title")
         if len(titles) > 0:
             caller_name = titles[0].get_text()
             caller_name = caller_name.replace("\n", "").strip(" ")
+            # TODO: if score == 1, check for "Political", "Charity", and/or "Debt Collector" 
+            # in the caller_name and adjust the score if appropriate 
 
         spam = False if score < args.spamscore else True
         return self.onlinecheck_2_result(spam, score, caller_name)

--- a/usr/share/callblocker/onlinecheck_nomorobo_com.py
+++ b/usr/share/callblocker/onlinecheck_nomorobo_com.py
@@ -41,7 +41,9 @@ class OnlineCheckNomorobo(OnlineBase):
             position = positions[0].get_text()
             self.log.debug("profile_position: " + position)
             if position.upper().find("DO NOT ANSWER") > -1:
-                score = 2
+                score = 2 # is spam
+            else
+                score = 1 # may be spam
 
         caller_name = ""
         titles = soup.findAll(class_="profile-title")

--- a/usr/share/callblocker/onlinecheck_nomorobo_com.py
+++ b/usr/share/callblocker/onlinecheck_nomorobo_com.py
@@ -39,7 +39,6 @@ class OnlineCheckNomorobo(OnlineBase):
         positions = soup.findAll(class_="profile-position")
         if len(positions) > 0:
             position = positions[0].get_text()
-            self.log.debug("profile_position: " + position)
             if position.upper().find("DO NOT ANSWER") > -1:
                 score = 2 # is spam
             else
@@ -49,9 +48,7 @@ class OnlineCheckNomorobo(OnlineBase):
         titles = soup.findAll(class_="profile-title")
         if len(titles) > 0:
             caller_name = titles[0].get_text()
-            self.log.debug("profile_title: " + caller_name)
             caller_name = caller_name.replace("\n", "").strip(" ")
-
 
         spam = False if score < args.spamscore else True
         return self.onlinecheck_2_result(spam, score, caller_name)
@@ -61,7 +58,7 @@ class OnlineCheckNomorobo(OnlineBase):
 #
 if __name__ == "__main__":
     m = OnlineCheckNomorobo()
-    parser = m.get_parser("Online check via nomorobo.com")
+    parser = m.get_parser("Online check via www.nomorobo.com")
     parser.add_argument("--spamscore", help="score limit to mark as spam [1..2]", default=2)
     args = parser.parse_args()
     m.run(args)

--- a/usr/share/callblocker/onlinecheck_nomorobo_com.py
+++ b/usr/share/callblocker/onlinecheck_nomorobo_com.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+# callblocker - blocking unwanted calls from your home phone
+# Copyright (C) 2015-2017 Patrick Ammann <pammann@gmx.net>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+
+import sys
+from bs4 import BeautifulSoup
+from online_base import OnlineBase
+
+class OnlineCheckNomorobo(OnlineBase):
+    def supported_country_codes(self):
+        return ["+1"]
+
+    def handle_number(self, args, number):
+        number = '{}-{}-{}'.format(number[2:5], number[5:8], number[8:]) # make number local
+        url = "https://www.nomorobo.com/lookup/%s" % number
+        headers={}
+        allowed_codes=[404] # allow not found response
+        content = self.http_get(url, headers, allowed_codes )
+        soup = BeautifulSoup(content, "lxml")
+        self.log.debug(soup)
+
+        score = 0  # = no spam
+        positions = soup.findAll(class_="profile-position")
+        if len(positions) > 0:
+            position = positions[0].get_text()
+            self.log.debug("profile_position: " + position)
+            if position.upper().find("DO NOT ANSWER") > -1:
+                score = 2
+
+        caller_name = ""
+        titles = soup.findAll(class_="profile-title")
+        if len(titles) > 0:
+            caller_name = titles[0].get_text()
+            self.log.debug("profile_title: " + caller_name)
+            caller_name = caller_name.replace("\n", "").strip(" ")
+
+
+        spam = False if score < args.spamscore else True
+        return self.onlinecheck_2_result(spam, score, caller_name)
+
+#
+# main
+#
+if __name__ == "__main__":
+    m = OnlineCheckNomorobo()
+    parser = m.get_parser("Online check via nomorobo.com")
+    parser.add_argument("--spamscore", help="score limit to mark as spam [1..2]", default=2)
+    args = parser.parse_args()
+    m.run(args)

--- a/usr/share/callblocker/onlinecheck_nomorobo_com.py
+++ b/usr/share/callblocker/onlinecheck_nomorobo_com.py
@@ -41,7 +41,7 @@ class OnlineCheckNomorobo(OnlineBase):
             position = positions[0].get_text()
             if position.upper().find("DO NOT ANSWER") > -1:
                 score = 2 # is spam
-            else
+            else:
                 score = 1 # may be spam
 
         caller_name = ""


### PR DESCRIPTION
### Description
Adds support for the U.S. Nomorobo lookup service.  The online check queries the lookup service for a US phone number and parses the returned web page to determine spam score.  The online check returns a score of 0..2.

Closes #29 

### Scores
0: **no spam**, if number is not in the lookup (service returns 404, not found)
1: **might be spam**, if number is found in lookup but has not been tagged with "Do not answer.", for instance, if caller is "Political", "Charity", or "Debt Collector" (as seen in the caller name)
2: **is spam**, if number is found in lookup and is tagged with "Do not answer."

### Tests
Here are some test phone numbers:
- +14153250308 (Robocaller)
- +13232304560 (Political)

