### PR TITLE
ignore decoding errors while parsing blacklists

### DIFF
--- a/usr/share/callblocker/blacklist_base.py
+++ b/usr/share/callblocker/blacklist_base.py
@@ -44,7 +44,7 @@ class BlacklistBase(object):
         req = urllib.request.Request(url, headers=headers)
         data = urllib.request.urlopen(req, timeout=60)
         ret = data.read()
-        ret = ret.decode("utf-8")
+        ret = ret.decode("utf-8", "ignore")
         return str(ret)
 
     def minimize_name(self, name):


### PR DESCRIPTION
I am on Raspbian stretch on Rpi v1 and got an error while parsing the supplied us blacklist. 
`'utf8' codec can't decode byte 0x9c`
This fixed it for me. I did have correct Local setup btw.